### PR TITLE
Support escaping delimiter with a definable character

### DIFF
--- a/Src/KBCsv/CsvReader.cs
+++ b/Src/KBCsv/CsvReader.cs
@@ -275,9 +275,6 @@
         /// This property specifies what character is used to escape values within the CSV. This is normally only required when the CSV is not following RFC 4180,
         /// e.g. the delimiter is escaped as \" rather than ""
         /// </para>
-        /// <para>
-        /// Note that values within the CSV are not required to be delimited. However, delimiting a value allows it to contain the delimiter character itself, along with new line characters (ie. a multi-line value).
-        /// </para>
         /// </remarks>
         public char? EscapeCharacter
         {

--- a/Src/KBCsv/CsvReader.cs
+++ b/Src/KBCsv/CsvReader.cs
@@ -268,6 +268,33 @@
         }
 
         /// <summary>
+        /// Gets or sets the character used to escape values (normally the ValueDelimiter.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This property specifies what character is used to escape values within the CSV. This is normally only required when the CSV is not following RFC 4180,
+        /// e.g. the delimiter is escaped as \" rather than ""
+        /// </para>
+        /// <para>
+        /// Note that values within the CSV are not required to be delimited. However, delimiting a value allows it to contain the delimiter character itself, along with new line characters (ie. a multi-line value).
+        /// </para>
+        /// </remarks>
+        public char? EscapeCharacter
+        {
+            get
+            {
+                this.EnsureNotDisposed();
+                return this.parser.EscapeCharacter;
+            }
+
+            set
+            {
+                this.EnsureNotDisposed();
+                this.parser.EscapeCharacter = value;
+            }
+        }
+
+        /// <summary>
         /// Gets or sets the header record.
         /// </summary>
         /// <remarks>

--- a/Src/KBCsv/CsvReader.cs
+++ b/Src/KBCsv/CsvReader.cs
@@ -268,7 +268,7 @@
         }
 
         /// <summary>
-        /// Gets or sets the character used to escape values (normally the ValueDelimiter.
+        /// Gets or sets the character used to escape values (normally to escape the ValueDelimiter)
         /// </summary>
         /// <remarks>
         /// <para>

--- a/Src/KBCsv/Internal/CsvParser_Async.cs
+++ b/Src/KBCsv/Internal/CsvParser_Async.cs
@@ -15,6 +15,7 @@
 
             var skipped = 0;
             var delimited = false;
+            var escaped = false;
 
             while (skipped < skip)
             {
@@ -26,13 +27,24 @@
                         {
                             var ch = this.buffer[this.bufferIndex++];
 
-                            if (!this.IsPossiblySpecialCharacter(ch))
+                            if (escaped)
+                            {
+                                // we had an escape character previous, just insert this as whatever character it is
+                                this.valueBuilder.NotifyPreviousCharIncluded(true);
+                                escaped = false;
+                            }
+                            else if (ch == this.escapeCharacter)
+                            {
+                                // User specified escape character, do not insert into value, next read character is not special
+                                this.valueBuilder.NotifyPreviousCharExcluded();
+                                escaped = true;
+                            }
+                            else if (!this.IsPossiblySpecialCharacter(ch))
                             {
                                 // if it's definitely not a special character, then we can just continue on with the loop
                                 continue;
                             }
-
-                            if (!delimited)
+                            else if (!delimited)
                             {
                                 if (ch == this.valueDelimiter)
                                 {
@@ -109,6 +121,7 @@
             var ch = char.MinValue;
             var recordsParsed = 0;
             var delimited = false;
+            var escaped = false;
 
             for (var i = offset; i < offset + count; ++i)
             {
@@ -118,14 +131,25 @@
                     {
                         ch = this.buffer[this.bufferIndex++];
 
-                        if (!this.IsPossiblySpecialCharacter(ch))
+                        if (escaped)
+                        {
+                            // we had an escape character previous, just insert this as whatever character it is
+                            this.valueBuilder.NotifyPreviousCharIncluded(true);
+                            escaped = false;
+                        }
+                        else if (ch == this.escapeCharacter)
+                        {
+                            // User specified escape character, do not insert into value, next read character is not special
+                            this.valueBuilder.NotifyPreviousCharExcluded();
+                            escaped = true;
+                        }
+                        else if (!this.IsPossiblySpecialCharacter(ch))
                         {
                             // if it's definitely not a special character, then we can just append it and continue on with the loop
                             this.valueBuilder.NotifyPreviousCharIncluded(delimited);
                             continue;
                         }
-
-                        if (!delimited)
+                        else if (!delimited)
                         {
                             if (ch == this.valueSeparator)
                             {


### PR DESCRIPTION
This implements support for escaping the delimiter character with a user definable character and so allow support for reading in csv that use \" rather than "".